### PR TITLE
Install plugins into protected env

### DIFF
--- a/conda_self/cli/main_install.py
+++ b/conda_self/cli/main_install.py
@@ -20,5 +20,12 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
 
 
 def execute(args: argparse.Namespace) -> int:
+    from ..install import install_specs_in_protected_env
+
     print("Installing plugins:", *args.specs)
-    return 0
+
+    return install_specs_in_protected_env(
+        args.specs,
+        force_reinstall=args.force_reinstall,
+        json=False,
+    )

--- a/conda_self/cli/main_install.py
+++ b/conda_self/cli/main_install.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from conda.exceptions import CondaValueError
+
 if TYPE_CHECKING:
     import argparse
 
@@ -20,12 +22,38 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
 
 
 def execute(args: argparse.Namespace) -> int:
-    from ..install import install_specs_in_protected_env
+    from ..install import install_specs_in_protected_env, uninstall_specs_in_protected_env
+    from ..validate import validate_plugin_is_installed
+    from ..query import check_installed
 
     print("Installing plugins:", *args.specs)
 
-    return install_specs_in_protected_env(
+    result = install_specs_in_protected_env(
         args.specs,
         force_reinstall=args.force_reinstall,
         json=False,
     )
+
+    # if the install has failed, make sure we are still in a good state
+    if result != 0:
+        print(f"Error installing requested packages into the base environment")
+        return result
+
+    non_plugin_specs = []
+    for spec in args.specs:
+        # ensure that the spec is installed
+        installed = check_installed(spec)
+        if installed is not None:
+            try:
+                # ensure the spec is a plugin
+                validate_plugin_is_installed(spec)
+            except CondaValueError:
+                non_plugin_specs.append(spec)
+
+    if len(non_plugin_specs) > 0:
+        print(
+              f"""
+            WARNING: The following specs are not plugins: {non_plugin_specs}.
+            Rolling back!
+            """)
+        uninstall_specs_in_protected_env(non_plugin_specs)

--- a/conda_self/cli/main_update.py
+++ b/conda_self/cli/main_update.py
@@ -37,7 +37,7 @@ def execute(args: argparse.Namespace) -> int:
     from conda.reporters import get_spinner
 
     from ..query import check_updates
-    from ..update import install_package_in_protected_env
+    from ..install import install_package_in_protected_env
     from ..validate import validate_plugin_is_installed
 
     if args.plugin:

--- a/conda_self/cli/main_update.py
+++ b/conda_self/cli/main_update.py
@@ -38,14 +38,14 @@ def execute(args: argparse.Namespace) -> int:
 
     from ..query import check_updates
     from ..update import install_package_in_protected_env
-    from ..validate import validate_plugin_name
+    from ..validate import validate_plugin_is_installed
 
     if args.plugin:
         if sys.version_info < (3, 12):
             raise CondaError(
                 "'--plugin' is only available on installations using Python 3.12+."
             )
-        validate_plugin_name(args.plugin)
+        validate_plugin_is_installed(args.plugin)
         package_name = args.plugin
     else:
         package_name = "conda"

--- a/conda_self/install.py
+++ b/conda_self/install.py
@@ -39,6 +39,7 @@ def install_specs_in_protected_env(
     channel: str = None,
     force_reinstall: bool = False,
     json: bool = False,
+    yes: bool = True,
 ) -> int:
     cmd = [
             sys.executable,
@@ -53,7 +54,33 @@ def install_specs_in_protected_env(
             ),
             *(("--force-reinstall",) if force_reinstall else ()),
             *(("--json",) if json else ()),
-            *((f"--channel={channel}", "--override-channels") if channel is not None else ()),
+            "--override-channels",
+            *((f"--channel={channel}") if channel is not None else (f"--channel={chn}" for chn in context.channels)),
+            *(("--yes",) if yes else ()),
+            *specs
+        ]
+    process = run(cmd)
+    return process.returncode
+
+
+def uninstall_specs_in_protected_env(
+    specs: list[str],
+    json: bool = False,
+    yes: bool = True,
+) -> int:
+    cmd = [
+            sys.executable,
+            "-m",
+            "conda",
+            "remove",
+            f"--prefix={sys.prefix}",
+            *(
+                ("--override-frozen",)
+                if hasattr(context, "protect_frozen_envs")
+                else ()
+            ),
+            *(("--json",) if json else ()),
+            *(("--yes",) if yes else ()),
             *specs
         ]
     process = run(cmd)

--- a/conda_self/install.py
+++ b/conda_self/install.py
@@ -32,3 +32,29 @@ def install_package_in_protected_env(
         ]
     )
     return process.returncode
+
+
+def install_specs_in_protected_env(
+    specs: list[str],
+    channel: str = None,
+    force_reinstall: bool = False,
+    json: bool = False,
+) -> int:
+    cmd = [
+            sys.executable,
+            "-m",
+            "conda",
+            "install",
+            f"--prefix={sys.prefix}",
+            *(
+                ("--override-frozen",)
+                if hasattr(context, "protect_frozen_envs")
+                else ()
+            ),
+            *(("--force-reinstall",) if force_reinstall else ()),
+            *(("--json",) if json else ()),
+            *((f"--channel={channel}", "--override-channels") if channel is not None else ()),
+            *specs
+        ]
+    process = run(cmd)
+    return process.returncode

--- a/conda_self/query.py
+++ b/conda_self/query.py
@@ -22,14 +22,21 @@ if TYPE_CHECKING:
     from conda.models.records import PackageRecord, PrefixRecord
 
 
+def check_installed(
+    package_name: str,
+    prefix: PathType = sys.prefix,
+) -> PackageRecord:
+    installed = PrefixData(prefix).get(package_name)
+    if not installed:
+        raise PackageNotInstalledError(prefix, package_name)
+    return installed
+
+
 def check_updates(
     package_name: str,
     prefix: PathType = sys.prefix,
 ) -> tuple[bool, PrefixRecord, PackageRecord | None]:
-    installed = PrefixData(prefix).get(package_name)
-    if not installed:
-        raise PackageNotInstalledError(prefix, package_name)
-
+    installed = check_installed(package_name, prefix)
     subdir = installed.subdir
     subdirs = (subdir, (context.subdir if subdir == "noarch" else "noarch"))
     latest_available = latest(installed.name, installed.channel.base_url, subdirs)

--- a/conda_self/query.py
+++ b/conda_self/query.py
@@ -26,17 +26,20 @@ def check_installed(
     package_name: str,
     prefix: PathType = sys.prefix,
 ) -> PackageRecord:
-    installed = PrefixData(prefix).get(package_name)
-    if not installed:
-        raise PackageNotInstalledError(prefix, package_name)
-    return installed
+    installed = tuple(PrefixData(prefix).query(package_name))
+    if len(installed) == 0:
+        return None
+    return installed[0]
 
 
 def check_updates(
     package_name: str,
     prefix: PathType = sys.prefix,
 ) -> tuple[bool, PrefixRecord, PackageRecord | None]:
-    installed = check_installed(package_name, prefix)
+    installed = tuple(PrefixData(prefix).query(package_name))
+    if len(installed) == 0:
+        raise PackageNotInstalledError(prefix, package_name)
+
     subdir = installed.subdir
     subdirs = (subdir, (context.subdir if subdir == "noarch" else "noarch"))
     latest_available = latest(installed.name, installed.channel.base_url, subdirs)

--- a/conda_self/validate.py
+++ b/conda_self/validate.py
@@ -17,7 +17,7 @@ def conda_plugin_packages():
     )
 
 
-def validate_plugin_name(name: str) -> None:
+def validate_plugin_is_installed(name: str) -> None:
     if name not in conda_plugin_packages():
         raise CondaValueError(
             f"Package '{name}' does not seem to be a valid conda plugin. Try one of:\n- "


### PR DESCRIPTION
The PR takes a naive approach at implementing installing plugins into the conda base environment. Only plugins are allowed to be installed into the base environemnt. If the user tries to install a non-plugin package, conda-self will uninstall offending packages. 

To try it out:

```
$ pixi run conda self install flask      
Installing plugins: flask
Channels:
 - defaults
Platform: linux-64
Collecting package metadata (repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: /home/sophia/projects/conda-self/.pixi/envs/default

  added / updated specs:
    - flask


The following NEW packages will be INSTALLED:

  blinker            pkgs/main/linux-64::blinker-1.9.0-py313h06a4308_0 
  click              pkgs/main/linux-64::click-8.1.8-py313h06a4308_0 
  flask              pkgs/main/linux-64::flask-3.1.0-py313h06a4308_0 
  itsdangerous       pkgs/main/linux-64::itsdangerous-2.2.0-py313h06a4308_0 
  jinja2             pkgs/main/linux-64::jinja2-3.1.6-py313h06a4308_0 
  markupsafe         pkgs/main/linux-64::markupsafe-3.0.2-py313h5eee18b_0 
  werkzeug           pkgs/main/linux-64::werkzeug-3.1.3-py313h06a4308_0 



Downloading and Extracting Packages:

Preparing transaction: done
Verifying transaction: done
Executing transaction: done

            WARNING: The following specs are not plugins: ['flask'].
            Rolling back!
            
Channels:
 - defaults
Platform: linux-64
Collecting package metadata (repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: /home/sophia/projects/conda-self/.pixi/envs/default

  removed specs:
    - flask


The following packages will be REMOVED:

  blinker-1.9.0-py313h06a4308_0
  click-8.1.8-py313h06a4308_0
  flask-3.1.0-py313h06a4308_0
  itsdangerous-2.2.0-py313h06a4308_0
  jinja2-3.1.6-py313h06a4308_0
  markupsafe-3.0.2-py313h5eee18b_0
  werkzeug-3.1.3-py313h06a4308_0



Downloading and Extracting Packages:

Preparing transaction: done
Verifying transaction: done
Executing transaction: done
```