### PR TITLE
Install into self - validate before install

### DIFF
--- a/conda_self/cli/main_install.py
+++ b/conda_self/cli/main_install.py
@@ -36,6 +36,7 @@ def execute(args: argparse.Namespace) -> int:
     from conda.misc import _match_specs_from_explicit
     from conda.reporters import confirm_yn
 
+    from ..exceptions import SpecsAreNotPlugins
     from ..package_info import PackageInfo
 
     print("Installing plugins:", *args.specs)
@@ -69,9 +70,7 @@ def execute(args: argparse.Namespace) -> int:
             invalid_specs.append(pcr.name)
     
     if invalid_specs:
-        print(f"The following requested specs are not plugins: {invalid_specs}")
-        print("Aborting install!")
-        return 1
+        raise SpecsAreNotPlugins(invalid_specs)
 
     if not context.json:
         transaction.print_transaction_summary()

--- a/conda_self/cli/main_install.py
+++ b/conda_self/cli/main_install.py
@@ -20,5 +20,42 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
 
 
 def execute(args: argparse.Namespace) -> int:
+    import sys
+
+    from conda.api import Solver, PackageCacheData
+    from conda.base.context import context
+    from conda.cli.common import arg2spec
+    from conda.exceptions import CondaValueError
+
+
+    from ..validate import validate_plugin_is_installed
+
     print("Installing plugins:", *args.specs)
+
+    specs_to_add = [arg2spec(spec) for spec in args.specs]
+    solver = Solver(
+        sys.prefix, context.channels, specs_to_add=specs_to_add
+    )
+    transaction =  solver.solve_for_transaction()
+    transaction.download_and_extract()
+
+    link_precs = [precs for precs in transaction.prefix_setups[sys.prefix].link_precs if precs.name in args.specs]    
+    package_cache_records = [PackageCacheData.query_all(prec)[0] for prec in link_precs]
+    for pcr in package_cache_records:
+        # hmmm, maybe a lil wild
+        sys.path.append(pcr.extracted_package_dir)
+    
+    invalid_specs = []
+    for spec in args.specs:
+        try:
+            validate_plugin_is_installed(spec)
+        except CondaValueError:
+            invalid_specs.append(spec)
+    
+    if invalid_specs:
+        print(f"The following requested specs are not plugins: {invalid_specs}")
+        print("Aborting install!")
+        return 1
+
+    # TODO: execute transaction      
     return 0

--- a/conda_self/cli/main_install.py
+++ b/conda_self/cli/main_install.py
@@ -15,6 +15,11 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Reinstall plugin even if it's already installed.",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Only report available updates, do not install.",
+    )
     parser.add_argument("specs", nargs="+", help="Plugins to install")
     parser.set_defaults(func=execute)
 
@@ -24,29 +29,45 @@ def execute(args: argparse.Namespace) -> int:
 
     from conda.api import Solver, PackageCacheData
     from conda.base.context import context
-    from conda.cli.common import arg2spec
-    from conda.exceptions import CondaValueError
-
+    from conda.cli.common import stdout_json_success
+    from conda.common.path import is_package_file
+    from conda.exceptions import CondaValueError, DryRunExit
+    from conda.models.match_spec import MatchSpec
+    from conda.misc import _match_specs_from_explicit
+    from conda.reporters import confirm_yn
 
     from ..validate import validate_plugin_is_installed
 
     print("Installing plugins:", *args.specs)
 
-    specs_to_add = [arg2spec(spec) for spec in args.specs]
+    specs_to_add = []
+
+    num_cp = sum(is_package_file(s) for s in args.specs)
+    if num_cp:
+        if num_cp == len(args.specs):
+            specs_to_add = list(_match_specs_from_explicit(args.specs))
+        else:
+            raise CondaValueError(
+                "cannot mix specifications with conda package filenames"
+            )
+    else:
+        specs_to_add = [MatchSpec(spec) for spec in args.specs]
+
     solver = Solver(
         sys.prefix, context.channels, specs_to_add=specs_to_add
     )
     transaction =  solver.solve_for_transaction()
     transaction.download_and_extract()
 
-    link_precs = [precs for precs in transaction.prefix_setups[sys.prefix].link_precs if precs.name in args.specs]    
+    specs_to_add_names = [spec.name for spec in specs_to_add]
+    link_precs = [precs for precs in transaction.prefix_setups[sys.prefix].link_precs if precs.name in specs_to_add_names]    
     package_cache_records = [PackageCacheData.query_all(prec)[0] for prec in link_precs]
     for pcr in package_cache_records:
         # hmmm, maybe a lil wild
-        sys.path.append(pcr.extracted_package_dir)
+        sys.path.append(f"{pcr.extracted_package_dir}/site-packages")
     
     invalid_specs = []
-    for spec in args.specs:
+    for spec in specs_to_add_names:
         try:
             validate_plugin_is_installed(spec)
         except CondaValueError:
@@ -57,5 +78,18 @@ def execute(args: argparse.Namespace) -> int:
         print("Aborting install!")
         return 1
 
-    # TODO: execute transaction      
+    if not context.json:
+        transaction.print_transaction_summary()
+        confirm_yn()
+    elif context.dry_run:
+        actions = transaction._make_legacy_action_groups()[0]
+        stdout_json_success(prefix=sys.prefix, actions=actions, dry_run=True)
+        raise DryRunExit()
+
+    transaction.execute()    
+
+    if context.json:
+        actions = transaction._make_legacy_action_groups()[0]
+        stdout_json_success(prefix=sys.prefix, actions=actions)
+
     return 0

--- a/conda_self/cli/main_update.py
+++ b/conda_self/cli/main_update.py
@@ -38,14 +38,14 @@ def execute(args: argparse.Namespace) -> int:
 
     from ..query import check_updates
     from ..update import install_package_in_protected_env
-    from ..validate import validate_plugin_name
+    from ..validate import validate_plugin_is_installed
 
     if args.plugin:
         if sys.version_info < (3, 12):
             raise CondaError(
                 "'--plugin' is only available on installations using Python 3.12+."
             )
-        validate_plugin_name(args.plugin)
+        validate_plugin_is_installed(args.plugin)
         package_name = args.plugin
     else:
         package_name = "conda"

--- a/conda_self/exceptions.py
+++ b/conda_self/exceptions.py
@@ -1,0 +1,6 @@
+from conda.exceptions import CondaError
+
+
+class SpecsAreNotPlugins(CondaError):
+    def __init__(self, specs: list[str]):
+        super().__init__(f"The following requested specs are not plugins: {specs}")

--- a/conda_self/package_info.py
+++ b/conda_self/package_info.py
@@ -1,0 +1,62 @@
+import configparser
+from conda.exceptions import CondaError
+from pathlib import Path
+
+
+class MultipleDistInfoDirsFound(CondaError):
+    pass
+
+
+class NoDistInfoDirFound(CondaError):
+    pass
+
+
+# This is required for reading entry point info from an extracted package
+# ref: https://packaging.python.org/en/latest/specifications/entry-points/#file-format 
+class CaseSensitiveConfigParser(configparser.ConfigParser):
+    optionxform = staticmethod(str)
+
+
+class PackageInfo():
+    def __init__(self, dist_info_path: Path):
+        """Describe the dist-info for a conda package"""
+        self.dist_info_path = dist_info_path
+    
+    @classmethod
+    def from_conda_extracted_package_path(cls, path: str):
+        """Create a PackageInfo object given the path to an extracted conda package"""
+        path = Path(path)
+        matching_paths = [p for p in path.rglob("**/*site-packages/*dist-info*") if p.is_dir()]
+        if len(matching_paths) > 1:
+            raise MultipleDistInfoDirsFound()
+        elif len(matching_paths) == 0:
+            raise NoDistInfoDirFound()
+        return cls(matching_paths[0])
+
+    def entry_points(self) -> dict[str, dict[str, str]]:
+        """Get the entry points for a package.
+        
+        The return value for this function has the form:
+
+        {
+            entry_point_group:{
+                name: entry_point,
+                . . .
+            }
+            . . .
+        }
+        
+        :returns: a dictionary of entry point groups and the corresponding entry points 
+                  expressed as a dict.
+
+        ref: https://packaging.python.org/en/latest/specifications/entry-points/#file-format
+        """
+        entry_point_file = self.dist_info_path / "entry_points.txt"
+        entry_points_config = CaseSensitiveConfigParser()
+        entry_points_config.read(entry_point_file)
+
+        entry_points = {}
+        for section in entry_points_config.sections():
+            entry_points[section] = dict(entry_points_config[section])
+    
+        return entry_points

--- a/conda_self/validate.py
+++ b/conda_self/validate.py
@@ -1,9 +1,11 @@
 import sys
+from functools import cache
 from importlib.metadata import entry_points
 
 from conda.exceptions import CondaValueError
 
 
+@cache
 def conda_plugin_packages():
     if sys.version_info < (3, 12):
         raise RuntimeError("This function requires Python 3.12+")

--- a/conda_self/validate.py
+++ b/conda_self/validate.py
@@ -17,7 +17,7 @@ def conda_plugin_packages():
     )
 
 
-def validate_plugin_name(name: str) -> None:
+def validate_plugin_is_installed(name: str) -> None:
     if name not in conda_plugin_packages():
         raise CondaValueError(
             f"Package '{name}' does not seem to be a valid conda plugin. Try one of:\n- "

--- a/conda_self/validate.py
+++ b/conda_self/validate.py
@@ -1,11 +1,9 @@
 import sys
-from functools import cache
 from importlib.metadata import entry_points
 
 from conda.exceptions import CondaValueError
 
 
-@cache
 def conda_plugin_packages():
     if sys.version_info < (3, 12):
         raise RuntimeError("This function requires Python 3.12+")


### PR DESCRIPTION
This is an alternative to the install functionality presented in https://github.com/jaimergp/conda-self/pull/3. In this approach, conda-self uses the conda api (and sometimes some private functions :skull: ) in order to download and inspect requested specs for conda entry points before installing the packages. conda-self will abort installation if the package is found not to be a conda plugin. For example:

Installing a custom conda plugin
```
$ pixi run conda self install /home/sophia/miniconda3/conda-bld/noarch/conda-declarative-0.0.0dev0-py_0.tar.bz2

Installing plugins: /home/sophia/miniconda3/conda-bld/noarch/conda-declarative-0.0.0dev0-py_0.tar.bz2
Channels:
 - defaults
 - file:///home/sophia/miniconda3/conda-bld
Platform: linux-64
Collecting package metadata (repodata.json): done
Solving environment: done

Downloading and Extracting Packages:


## Package Plan ##

  environment location: /home/sophia/projects/conda-self/.pixi/envs/default

  added / updated specs:
    - conda-bld/noarch::conda-declarative==0.0.0dev0=py_0

Proceed ([y]/n)? y

Preparing transaction: done
Verifying transaction: done
Executing transaction: done
```

Installing a non-plugin conda package
```
$ pixi run conda self install flask                
Installing plugins: flask
Channels:
 - defaults
Platform: linux-64
Collecting package metadata (repodata.json): done
Solving environment: done

Downloading and Extracting Packages:

The following requested specs are not plugins: ['flask']
Aborting install!
```